### PR TITLE
Filter modules by level

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,7 @@ app.layout = dbc.Container([
                     tab_id="more_tab",
                     ),
         ],
-        active_tab="explore_pathways_tab",
+        active_tab="explore_modules_tab",
         id="navigation_tabs"
         )
         ),

--- a/app.py
+++ b/app.py
@@ -118,7 +118,8 @@ app.layout = dbc.Container([
                     tab_id="more_tab",
                     ),
         ],
-        active_tab="explore_pathways_tab"
+        active_tab="explore_pathways_tab",
+        id="navigation_tabs"
         )
         ),
     html.Div(hidden_filtered_modules), # DONT COMMENT OUT this is visible for debugging purposes, change to 'display': 'none' for production purposes. 
@@ -148,6 +149,7 @@ show_network_graph(app) # Displays a modal of the network graph :)
 ## Multi-page callbacks
 modal_card_pop_up(app) # Opens the module details modal whether the module name is clicked on the Explore Modules page or the Your Learning Pathway page
 callbacks.update_pathway.update_pathway(app) # Updates the user's pathway based on interactions on the Explore Modules, Explore Pathways, and Your Learning Pathway pages.
+callbacks.update_pathway.add_pathway_chage_tab(app)
 
 # turn on the debugger if using it
 #callbacks.debugger.debugger(app)

--- a/app.py
+++ b/app.py
@@ -89,31 +89,36 @@ app.layout = dbc.Container([
                          ]),
                     label="Explore Modules", 
                     label_style={"color":CHOP.dark_blue}, 
+                    tab_id="explore_modules_tab",
                     activeTabClassName="fw-bold",
                     style={"background-color": CHOP.light_blue_tint[1]}
                     ),
             dbc.Tab(talk_to_educator_text, 
                     label="Talk to an Educator", 
                     label_style={"color":CHOP.dark_blue}, 
-                    activeTabClassName="fw-bold"
+                    activeTabClassName="fw-bold",
+                    tab_id="talk_to_educator_tab",
                     ),
             dbc.Tab(pre_made_pathways, 
                     label="Explore Pathways", 
                     label_style={"color":CHOP.dark_blue},                    
                     activeTabClassName="fw-bold",
-                    id="explore_pathways_tab"
+                    tab_id="explore_pathways_tab"
                     ),
             dbc.Tab(your_learning_pathway, 
                     label="Your Learning Pathway", 
                     label_style={"color":CHOP.dark_blue}, 
-                    activeTabClassName="fw-bold"
+                    activeTabClassName="fw-bold",
+                    tab_id="your_learning_pathway_tab",
                     ),
             dbc.Tab(more_text, 
                     label="More", 
                     label_style={"color":CHOP.dark_blue}, 
-                    activeTabClassName="fw-bold"
+                    activeTabClassName="fw-bold",
+                    tab_id="more_tab",
                     ),
-        ]
+        ],
+        active_tab="explore_pathways_tab"
         )
         ),
     html.Div(hidden_filtered_modules), # DONT COMMENT OUT this is visible for debugging purposes, change to 'display': 'none' for production purposes. 

--- a/assets/README.md
+++ b/assets/README.md
@@ -13,6 +13,9 @@ There are 5 pre-made pathways that users can select and then modify to meet thei
 ## Collections
 The attributres of the collections of modules, including their symbols, colors, and descriptions, are stored here.
 
+## Levels
+The way we calculate and describe module levels is stored here.
+
 ## CHOP assets
 - `CHOP_colors.py` contains the color definitions that match Children's Hospital of Philadelphia branding standards.
 - `RI_logo.png` is the Research Insitute's logo.

--- a/assets/collections.py
+++ b/assets/collections.py
@@ -1,4 +1,3 @@
-from dash import Dash, html, Input, Output, dcc, ctx, State
 import dash_bootstrap_components as dbc
 import module_data 
 import assets.CHOP_colors as CHOP

--- a/assets/levels.py
+++ b/assets/levels.py
@@ -1,0 +1,30 @@
+from dash import Dash, html, Input, Output, dcc, ctx, State
+import dash_bootstrap_components as dbc
+import module_data 
+import assets.CHOP_colors as CHOP
+from network_analysis.required_expertise_times import required_expertise_times
+
+level_dictionary = {0: {"level_name": "Intro",
+                        "level_description": "No prerequisites",
+                        },
+                    1: {"level_name": "Level 1",
+                        "level_description": "Less than 2 hours of prerequisites"
+                        },
+                    2: {"level_name": "Level 2",
+                        "level_description": "2 to 4 hours of prerequisites"
+                        },
+                    3: {"level_name": "Level 3",
+                        "level_description": "4 to 6 hours of prerequisites"
+                        },
+                    4: {"level_name": "Level 4",
+                        "level_description": "6 to 8 hours of prerequisites"
+                        },
+                    5: {"level_name": "Level 5",
+                        "level_description": "More than 8 hours of prerequisites"
+                        },
+                    }
+
+def module_level(module_id):
+    return (required_expertise_times(module_id)-1)//120 + 1
+
+

--- a/assets/levels.py
+++ b/assets/levels.py
@@ -1,7 +1,3 @@
-from dash import Dash, html, Input, Output, dcc, ctx, State
-import dash_bootstrap_components as dbc
-import module_data 
-import assets.CHOP_colors as CHOP
 from network_analysis.required_expertise_times import required_expertise_times
 
 level_dictionary = {0: {"level_name": "Intro",

--- a/assets/levels.py
+++ b/assets/levels.py
@@ -1,10 +1,10 @@
 from network_analysis.required_expertise_times import required_expertise_times
 
-level_dictionary = {0: {"level_name": "Intro",
+level_dictionary = {"intro": {"level_name": "Intro",
                         "level_description": "No prerequisites",
                         },
                     1: {"level_name": "Level 1",
-                        "level_description": "Less than 2 hours of prerequisites"
+                        "level_description": "Up to 2 hours of prerequisites"
                         },
                     2: {"level_name": "Level 2",
                         "level_description": "2 to 4 hours of prerequisites"
@@ -21,6 +21,9 @@ level_dictionary = {0: {"level_name": "Intro",
                     }
 
 def module_level(module_id):
-    return (required_expertise_times(module_id)-1)//120 + 1
+    if required_expertise_times(module_id) == 0:
+        return "intro"
+    else:
+        return ((required_expertise_times(module_id)-1)//120 + 1)
 
 

--- a/assets/levels.py
+++ b/assets/levels.py
@@ -15,9 +15,9 @@ level_dictionary = {"intro": {"level_name": "Intro",
                     4: {"level_name": "Level 4",
                         "level_description": "6 to 8 hours of prerequisites"
                         },
-                    5: {"level_name": "Level 5",
-                        "level_description": "More than 8 hours of prerequisites"
-                        },
+                    # 5: {"level_name": "Level 5",
+                    #     "level_description": "More than 8 hours of prerequisites"
+                    #     },
                     }
 
 def module_level(module_id):

--- a/callbacks/update_pathway.py
+++ b/callbacks/update_pathway.py
@@ -113,3 +113,10 @@ def update_pathway(app):
         
         return new_pathway
 
+def add_pathway_chage_tab(app):
+    @app.callback(Output('navigation_tabs', 'active_tab'),
+                  [Input("use_"+pathway["id"],'n_clicks') for pathway in pathway_list], #these buttons are for users to remove individual modules from their pathway
+                prevent_initial_call=True)
+    def switch_to_pathway_tab(*args):
+        if ctx.triggered_id:
+            return "your_learning_pathway_tab"

--- a/callbacks/update_search_results.py
+++ b/callbacks/update_search_results.py
@@ -1,11 +1,11 @@
 ### The update_search_results function takes the checklist and radio buttons from the left_hand_nav_bar and returns a list of all modules that match the given filters.
-from dash import Dash, html, Input, Output, dcc, ctx, State
-import dash_bootstrap_components as dbc
+from dash import Input, Output
 import module_data 
 from components.explore_modules.left_hand_nav_bar import search_panel 
+from assets.levels import module_level
 search_results = search_panel.search_results
 
-def update_search_results(general_options_value, coding_language_value, coding_level_value, data_task_value, data_domain_value, search_term, collection_value):
+def update_search_results(general_options_value, coding_language_value, coding_level_value,level_value, data_task_value, data_domain_value, search_term, collection_value):
     matching_modules = list(module_data.df.index).copy()
     non_matching_modules = []
     for module in module_data.df.index:
@@ -24,6 +24,9 @@ def update_search_results(general_options_value, coding_language_value, coding_l
                 tracker = tracker*0
         if coding_level_value: # coding level is a radio button, so the output is a string, not a list of strings
             if coding_level_value not in str(module_data.df.loc[module,'coding_level']).lower():
+                tracker = tracker*0
+        if level_value: # level is a radio button, so the output is a string, not a list of strings
+            if not level_value == module_level(module):
                 tracker = tracker*0
         if data_task_value: # coding level is a radio button, so the output is a string, not a list of strings
             if data_task_value not in str(module_data.df.loc[module,'data_task']).lower():
@@ -47,10 +50,11 @@ def update_hidden_filtered_modules(app):
                 Input('general_options_checklist', 'value'),
                 Input('coding_language_checklist', 'value'),
                 Input('coding_level_checklist', 'value'),
+                Input('level_checklist', 'value'),
                 Input('data_task_checklist', 'value'),
                 Input('data_domain_checklist', 'value'),
                 Input('search_input', 'value'),
                 Input('collection_checklist', 'value')
                 )
-    def filtering(value, coding_language_value, coding_level_value, data_task_value, data_domain_value, search_value, collection_value):
-        return update_search_results(value, coding_language_value, coding_level_value, data_task_value, data_domain_value, search_value, collection_value)[0]
+    def filtering(value, coding_language_value, coding_level_value, level_value, data_task_value, data_domain_value, search_value, collection_value):
+        return update_search_results(value, coding_language_value, coding_level_value, level_value, data_task_value, data_domain_value, search_value, collection_value)[0]

--- a/components/explore_modules/clickable_module_list/clickable_module_list_callbacks.py
+++ b/components/explore_modules/clickable_module_list/clickable_module_list_callbacks.py
@@ -28,6 +28,8 @@ def create_clickable_module_list(app):
          message = dcc.Markdown("Explore all "+str(total_modules)+" modules or use the filters and search bar to find modules that interest you.", style={'background-color': ''})
       elif number_of_matches == 0:
          message = dcc.Markdown("No modules match your current filters and search terms. Try modifying your search or use the **Clear all selections** button to start over.", style={'background-color': ''})
+      elif number_of_matches == 1:
+         message = dcc.Markdown("There is one module that matches your filters and search terms:", style={'background-color': ''})
       else:
          message = dcc.Markdown("There are "+str(number_of_matches)+" modules that match your filters and search terms:", style={'background-color': ''})
       return message

--- a/components/explore_modules/clickable_module_list/module_cards/module_level.py
+++ b/components/explore_modules/clickable_module_list/module_cards/module_level.py
@@ -2,8 +2,6 @@ from dash import dcc
 import dash_bootstrap_components as dbc
 import assets.CHOP_colors as CHOP
 from assets.levels import level_dictionary, module_level
-from network_analysis.required_expertise_times import required_expertise_times
-
 
 def module_level_icon(module_id):
   icons = []          

--- a/components/explore_modules/clickable_module_list/module_cards/module_level.py
+++ b/components/explore_modules/clickable_module_list/module_cards/module_level.py
@@ -1,20 +1,20 @@
 from dash import dcc
 import dash_bootstrap_components as dbc
 import assets.CHOP_colors as CHOP
-import module_data 
+from assets.levels import level_dictionary, module_level
 from network_analysis.required_expertise_times import required_expertise_times
 
 
 def module_level_icon(module_id):
   icons = []          
-  icons.append(dbc.Badge(["Level "+ str((required_expertise_times(module_id)-1)//120+1)], 
+  icons.append(dbc.Badge(level_dictionary[module_level(module_id)]["level_name"], 
                 style = {"color":CHOP.black}, #badge text color
                 color = CHOP.white,
                 id=module_id+"_level_badge"
                 #className="ms-1"
                 ))
   icons.append(dbc.Popover(
-              dbc.PopoverBody(dcc.Markdown(str(required_expertise_times(module_id))+" mins of prerequisites.")),
+              dbc.PopoverBody(dcc.Markdown(level_dictionary[module_level(module_id)]["level_description"])),
               target=module_id+"_level_badge",
               trigger="hover",
               placement="top"

--- a/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar.py
+++ b/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar.py
@@ -40,7 +40,7 @@ left_hand_nav_bar = dbc.Container([
 
     search_panel,
     html.Br(),
-    dbc.Button("Clear all selections", id="clear_all_selections",color="dark", outline=True, size="sm", className="me-1"),
+    dbc.Button("Clear all selections", id="clear_all_selections",color="dark", outline=True, size="sm", className="me-1", style={"background-color":CHOP.dark_blue_tint[2]}),
     html.Br(),
     html.Br(),
     # GENERAL OPTIONS
@@ -97,6 +97,26 @@ left_hand_nav_bar = dbc.Container([
     html.Br(),
     html.Br(),
 
+    # LEVEL
+
+    dbc.Button(
+    "Level",
+    id="level_collapse_button", color="dark", outline=True, size="sm", className="me-1"),
+        dbc.Badge("?", id="level_info_button", pill=True,  color="light", text_color="dark"),
+    level_popover(),
+    dbc.Collapse([
+    dbc.Col([
+        dcc.RadioItems(
+        options=[{'label': " "+level_dictionary[key]["level_description"], 'value': key} for key in level_dictionary.keys()]+[
+        {'label': html.A(' Clear selection', style={'color': 'grey'}), 'value': '', },
+        ],
+        id='level_checklist')
+    ],)],
+    id='level_collapse_checklist',
+    is_open=False,
+    ),
+    html.Br(),
+    html.Br(),
 
     # CODING LANGUAGE
 
@@ -153,27 +173,6 @@ left_hand_nav_bar = dbc.Container([
         id='coding_level_checklist')
     ],)],
     id='coding_level_collapse_checklist',
-    is_open=False,
-    ),
-    html.Br(),
-    html.Br(),
-
-    # LEVEL
-
-    dbc.Button(
-    "Level",
-    id="level_collapse_button", color="dark", outline=True, size="sm", className="me-1"),
-        dbc.Badge("?", id="level_info_button", pill=True,  color="light", text_color="dark"),
-    level_popover(),
-    dbc.Collapse([
-    dbc.Col([
-        dcc.RadioItems(
-        options=[{'label': " "+level_dictionary[key]["level_description"], 'value': key} for key in level_dictionary.keys()]+[
-        {'label': html.A(' Clear selection', style={'color': 'grey'}), 'value': '', },
-        ],
-        id='level_checklist')
-    ],)],
-    id='level_collapse_checklist',
     is_open=False,
     ),
     html.Br(),

--- a/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar.py
+++ b/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar.py
@@ -2,6 +2,7 @@ from dash import html, dcc
 import dash_bootstrap_components as dbc
 from .search_panel import search_panel as search_panel
 from assets.collections import collection_symbols_dict, collection_descriptions_dict, collection_names_dict
+from assets.levels import level_dictionary
 import assets.CHOP_colors as CHOP
 
 def collections_popover():
@@ -16,6 +17,18 @@ def collections_popover():
     return dbc.Popover(
                 dbc.PopoverBody(dcc.Markdown(popover_body)),
             target="collection_info_button",
+            trigger="hover",
+        )
+
+def level_popover():
+    popover_body = ""
+    for level in level_dictionary.keys():
+        popover_body += "**"+level_dictionary[level]["level_name"]+"**: "
+        popover_body += level_dictionary[level]["level_description"]
+        popover_body += "\n \n"
+    return dbc.Popover(
+                dbc.PopoverBody(dcc.Markdown(popover_body)),
+            target="level_info_button",
             trigger="hover",
         )
 
@@ -140,6 +153,27 @@ left_hand_nav_bar = dbc.Container([
         id='coding_level_checklist')
     ],)],
     id='coding_level_collapse_checklist',
+    is_open=False,
+    ),
+    html.Br(),
+    html.Br(),
+
+    # LEVEL
+
+    dbc.Button(
+    "Level",
+    id="level_collapse_button", color="dark", outline=True, size="sm", className="me-1"),
+        dbc.Badge("?", id="level_info_button", pill=True,  color="light", text_color="dark"),
+    level_popover(),
+    dbc.Collapse([
+    dbc.Col([
+        dcc.RadioItems(
+        options=[{'label': " "+level_dictionary[key]["level_description"], 'value': key} for key in level_dictionary.keys()]+[
+        {'label': html.A(' Clear selection', style={'color': 'grey'}), 'value': '', },
+        ],
+        id='level_checklist')
+    ],)],
+    id='level_collapse_checklist',
     is_open=False,
     ),
     html.Br(),

--- a/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar_callbacks.py
+++ b/components/explore_modules/left_hand_nav_bar/left_hand_nav_bar_callbacks.py
@@ -47,6 +47,17 @@ def get_left_hand_nav_bar_callbacks(app):
             return not is_open
         return is_open
     
+    # Level open/close
+    @app.callback(
+        Output("level_collapse_checklist", "is_open"),
+        [Input("level_collapse_button", "n_clicks")],
+        [State("level_collapse_checklist", "is_open")],
+        )
+    def toggle_collapse(n, is_open):
+        if n:
+            return not is_open
+        return is_open
+    
     # Data task open/close
     @app.callback(
         Output("data_task_collapse_checklist", "is_open"),
@@ -73,6 +84,7 @@ def get_left_hand_nav_bar_callbacks(app):
     @app.callback(Output("general_options_checklist", "value"),
         Output("coding_language_checklist", "value"),
         Output("coding_level_checklist", "value"),
+        Output("level_checklist", "value"),
         Output("data_task_checklist", "value"),
         Output("data_domain_checklist", "value"),
         Output("search_input", "value"),
@@ -82,4 +94,4 @@ def get_left_hand_nav_bar_callbacks(app):
     )
     def clear_all_selections(n_clicks):
         if n_clicks:
-            return [], '', '', '', '', '', ''
+            return [], '', '', '', '', '', '' , ''

--- a/components/talk_to_educator.py
+++ b/components/talk_to_educator.py
@@ -8,7 +8,7 @@ talk_to_educator_text = html.Div(children=[
                 dbc.Container([dcc.Markdown("## Want to talk to a person? \n \n  Arcus Education offers free Educational Consultations to members of the CHOP community. We can help you navigate these resources, build a pathway with you, and connect you to additional synchronous offerings.  \n \n "),
                 html.Br(),
                 html.A("Use your CHOP log-in to "),
-                html.A("book your Educational Consultaion", href = "https://outlook.office365.com/owa/calendar/BKG-StandardArcusEducationOfficeHours@chop.edu/bookings/s/T6CE7Ve6Ck-saLar2e1xYw2", target="_blank", style={"color":CHOP.dark_blue}),
+                html.A("book your Educational Consultation", href = "https://outlook.office365.com/owa/calendar/BKG-StandardArcusEducationOfficeHours@chop.edu/bookings/s/T6CE7Ve6Ck-saLar2e1xYw2", target="_blank", style={"color":CHOP.dark_blue}),
                 html.A(", or "),
                 html.A("check out our full bookings page.", href = "https://outlook.office365.com/book/BKG-StandardArcusEducationOfficeHours@chop.edu/", target="_blank", style={"color":CHOP.dark_blue})
                 ])])


### PR DESCRIPTION
This adds a "level" filter for modules and makes the descriptions of "Intro, Level 1, ..." clearer based on how many hours of prerequisites they have.

Also fixes a typo, and changes the behavior of "Choose Pathway" buttons to automatically redirect you to "Your Learning Pathway" tab.